### PR TITLE
simplify

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,4 +25,5 @@ const esDepUnitMock = R.curry((inPathArray, requested, from, resolved) => {
 // esDepUnitMock :: String|null -> String|null -> String|null -> Object
 const esDepUnit = esDepUnitMock([]);
 
-export { esDepUnit, esDepUnitMock };
+esDepUnit.depMock = esDepUnitMock;
+export default esDepUnit;


### PR DESCRIPTION
right now the problem is named exported functions, so you have to remember them `{ esDepUnit, esDepUnitMock }` and thats hard. one way is by default export `esDepUnit`, and mock one attack to default export. What do you think, @kinday?